### PR TITLE
Add MacOS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ NewSonicThing/NewSonicThing.pdb
 NewSonicThing/src/SourceCodeCleaner.exe
 NewSonicThing/Settings/ControllerLog.txt
 NewSonicThing/res/SaveData/*
+.DS_Store

--- a/NewSonicThing/src/renderEngine/Display.cpp
+++ b/NewSonicThing/src/renderEngine/Display.cpp
@@ -67,10 +67,14 @@ int Display::createDisplay()
         glfwWindowHint(GLFW_REFRESH_RATE, Display::F_HZ);
     }
 
-    int screenWidth  = Display::WINDOW_WIDTH;
-    int screenHeight = Display::WINDOW_HEIGHT;
+    int screenWidth;
+    int screenHeight;
 
-
+#ifdef __APPLE__
+    glfwWindowHint(GLFW_COCOA_RETINA_FRAMEBUFFER, GL_FALSE);
+#endif
+    screenWidth  = Display::WINDOW_WIDTH;
+    screenHeight = Display::WINDOW_HEIGHT;
     //int count;
     //const GLFWvidmode* modes = glfwGetVideoModes(monitor, &count);
 

--- a/NewSonicThing/src/toolbox/Input.cpp
+++ b/NewSonicThing/src/toolbox/Input.cpp
@@ -1,6 +1,6 @@
 #include <glad/glad.h>
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__APPLE__)
 #include <GLFW/glfw3.h>
 #include <SDL2/SDL.h>
 #else

--- a/makefile
+++ b/makefile
@@ -1,21 +1,30 @@
-TARGET_EXEC ?= ../NewSonicThing/SAB2.out
+UNAME_S := $(shell uname -s)
 
+TARGET_EXEC ?= ../NewSonicThing/SAB2.out
 BUILD_DIR ?= makebuild
 SRC_DIRS ?= NewSonicThing/src
 
 SRCS := $(shell find $(SRC_DIRS) -name *.cpp -or -name *.c)
+
+ifeq ($(UNAME_S),Darwin)
+	INC_FLAGS := $(shell pkg-config --cflags glfw3 ogg vorbis vorbisfile openal soil sdl2) -I./Libraries/Include/ # $(addprefix -I, $(shell find $(SRC_DIRS) -type d))
+	CFLAGS := -O3 -Wall -Wextra -MMD -MP
+	CPPFLAGS ?= $(INC_FLAGS)
+	ALL_LDFLAGS := -sectcreate __TEXT __info_plist Info.plist -lm -lpthread -ldl `pkg-config --static --libs glfw3 ogg vorbis vorbisfile openal soil sdl2` -framework OpenGL $(LDFLAGS)
+	CPPFLAGS += -D'fopen_s(pFile,filename,mode)=((*(pFile))=fopen((filename),(mode)))==NULL'
+	CXXFLAGS ?= -O3 -Wall -Wextra -MMD -MP -std=c++17
+else
+	INC_FLAGS := `pkg-config --cflags glfw3 ogg vorbis vorbisfile openal gl` $(shell find $(SRC_DIRS) -type d) -I./Libraries/Include/
+	CPPFLAGS ?= -O2 -Wall -Wextra $(INC_FLAGS) -MMD -MP # -D_GLIBCXX_USE_CXX11_ABI=0
+	ALL_LDFLAGS := -lSOIL -lSDL2 -lm -lpthread -ldl `pkg-config --static --libs glfw3 ogg vorbis vorbisfile openal gl` $(LDFLAGS)
+	CPPFLAGS += -D'fopen_s(pFile,filename,mode)=((*(pFile))=fopen((filename),(mode)))==NULL'
+endif
+
 OBJS := $(SRCS:%=$(BUILD_DIR)/%.o)
 DEPS := $(OBJS:.o=.d)
 
-INC_DIRS := $(shell find $(SRC_DIRS) -type d) ./Libraries/Include/
-INC_FLAGS := $(addprefix -I,$(INC_DIRS)) `pkg-config --cflags glfw3 ogg vorbis vorbisfile openal gl`
-
-CPPFLAGS ?= -O2 -Wall -Wextra $(INC_FLAGS) -MMD -MP # -D_GLIBCXX_USE_CXX11_ABI=0
-LDFLAGS := -lSOIL -lSDL2 -lm -lpthread -ldl `pkg-config --static --libs glfw3 ogg vorbis vorbisfile openal gl`
-CPPFLAGS += -D'fopen_s(pFile,filename,mode)=((*(pFile))=fopen((filename),(mode)))==NULL'
-
 $(BUILD_DIR)/$(TARGET_EXEC): $(OBJS)
-	$(CXX) $(OBJS) -o $@ $(LDFLAGS)
+	$(CXX) $(OBJS) -o $@ $(ALL_LDFLAGS)
 
 # c source
 $(BUILD_DIR)/%.c.o: %.c


### PR DESCRIPTION
Tweak the Makefile to add build flags for MacOS. I've tested it by building all dependencies from source, but before merging, I want to verify that this works with dependencies from Homebrew/MacPorts.

Also, I tried not to change the logic for general Linux building, but it's possible that I could've broken it. I'll need to verify.

- [ ] Homebrew compatibility
- [ ] MacPorts compatibility
- [ ] HiDPI compatibility (I can't figure out how to get it to create a window where the framebuffer/pixels are 1:1)
- [ ] Controller support (haven't tested yet, but it _probably_ works)